### PR TITLE
Resolved `unexpected end of JSON input` when `X-Ratelimit` header isn't returned from Doorkeeper API

### DIFF
--- a/client.go
+++ b/client.go
@@ -151,7 +151,19 @@ func (c *Client) get(path string, values url.Values) ([]byte, *RateLimit, error)
 		return nil, nil, errors.New(resp.Status)
 	}
 
+	body, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
 	xRateLimit := resp.Header.Get("X-Ratelimit")
+
+	if xRateLimit == "" {
+		var rateLimit RateLimit
+		return body, &rateLimit, nil
+	}
+
 	rawRateLimit, err := newRawRateLimitFromJSON(xRateLimit)
 
 	if err != nil {
@@ -159,12 +171,6 @@ func (c *Client) get(path string, values url.Values) ([]byte, *RateLimit, error)
 	}
 
 	rateLimit, err := rawRateLimit.toRateLimit()
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
 
 	if err != nil {
 		return nil, nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -295,6 +295,37 @@ func TestClient_GetGroup_WithLocale(t *testing.T) {
 	assert.Equal(t, wantRateLimit, rateLimit)
 }
 
+func TestClient_GetGroup_WithoutRateLimitHeader(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "https://api.doorkeeper.jp/groups/trbmeetup?locale=en",
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, readTestData(filepath.Join("testdata", "group-en.json")))
+			return resp, nil
+		},
+	)
+
+	c := NewClient("DOORKEEPER_ACCESS_TOKEN")
+	group, rateLimit, err := c.GetGroup("trbmeetup", WithLocale("en"))
+
+	assert.NoError(t, err)
+
+	wantGroup := &Group{
+		ID:           24,
+		Name:         "Tokyo Rubyist Meetup",
+		CountryCode:  "JP",
+		Logo:         "https://dzpp79ucibp5a.cloudfront.net/groups_logos/24_normal_1371637374_200px-Ruby_logo.png",
+		Description:  "<p>Tokyo Rubyist Meetup (trbmeetup) is an event that seeks to help bridge the Japan and international ruby and ruby on rails community. It will hold regular meetings where Japanese Rubyists can communicate with international Rubyists living in Tokyo. Meetings will be held in English, but anyone is encouraged to participate regardless of their ability.</p>\n",
+		PublicURL:    "https://trbmeetup.doorkeeper.jp/",
+		MembersCount: 2056,
+	}
+	assert.Equal(t, wantGroup, group)
+
+	wantRateLimit := &RateLimit{}
+	assert.Equal(t, wantRateLimit, rateLimit)
+}
+
 func TestClient_GetGroup_NotFound(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()


### PR DESCRIPTION
https://www.doorkeeper.jp/developer/api?locale=en says Doorkeeper API returns `X-Ratelimit` header, but Doorkeeper API suddenly stopped returning `X-Ratelimit` header 😭 

```
$ curl --verbose --header "Authorization: Bearer $DOORKEEPER_ACCESS_TOKEN" "https://api.doorkeeper.jp/groups/tokyu-rubykaigi"
*   Trying 13.57.55.246...
* TCP_NODELAY set
* Connected to api.doorkeeper.jp (13.57.55.246) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: CN=doorkeeper.jp
*  start date: Jan 22 00:00:00 2021 GMT
*  expire date: Feb 20 23:59:59 2022 GMT
*  subjectAltName: host "api.doorkeeper.jp" matched cert's "*.doorkeeper.jp"
*  issuer: C=US; O=Amazon; OU=Server CA 1B; CN=Amazon
*  SSL certificate verify ok.
> GET /groups/tokyu-rubykaigi HTTP/1.1
> Host: api.doorkeeper.jp
> User-Agent: curl/7.64.1
> Accept: */*
> Authorization: Bearer rSv-96tPJsZv7_sTrqfo
>
< HTTP/1.1 200 OK
< Cache-Control: max-age=0, private, must-revalidate
< Content-Type: application/json; charset=utf-8
< ETag: W/"56894f4ad0f7faebc1a718a66ce50bcd"
< Referrer-Policy: strict-origin-when-cross-origin
< Strict-Transport-Security: max-age=63072000; includeSubDomains
< Vary: Origin
< X-Content-Type-Options: nosniff
< X-Download-Options: noopen
< X-Frame-Options: SAMEORIGIN
< X-Permitted-Cross-Domain-Policies: none
< X-Request-Id: 37872a76-f5fc-4a46-912a-f2a402d0b1a8
< X-Runtime: 0.023480
< X-XSS-Protection: 1; mode=block
< Content-Length: 454
< Connection: keep-alive
<
* Connection #0 to host api.doorkeeper.jp left intact
{"group":{"id":681,"name":"TokyuRubyKaigi","country_code":"JP","logo":"https://dzpp79ucibp5a.cloudfront.net/assets/group_logos/848770_normal-e84ab0b517d6e0b99931f1b078ed975b7a3ffb4bcbe82010be04ecb65e706a71.png","description":"<p>Ruby に興味を持つエンジニアが集う <a href=\"http://qwik.jp/tokyurb/\" rel=\"nofollow\">Tokyu.rb</a> 主催の LT 大会です。</p>\n","public_url":"https://tokyu-rubykaigi.doorkeeper.jp/","members_count":518}}* Closing connection 0
```

All API executions will result in an error [here](https://github.com/sue445/go-doorkeeper/blob/v0.1.5/client.go#L155-L159)

So I ignored when `X-Ratelimit` header isn't be returned

# Error log
https://sentry.io/share/issue/4372fd05779148eb915cd7fad8752ad0/