### PR TITLE
Fix deprecation warning

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/pkg/errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -151,7 +151,7 @@ func (c *Client) get(path string, values url.Values) ([]byte, *RateLimit, error)
 		return nil, nil, errors.New(resp.Status)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return nil, nil, errors.WithStack(err)

--- a/client_test.go
+++ b/client_test.go
@@ -3,16 +3,16 @@ package doorkeeper
 import (
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 )
 
 func readTestData(filename string) string {
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
* `ioutil` has been deprecated since Go 1.16
* ref. https://go.dev/doc/go1.16